### PR TITLE
Show memory on start, visualizer

### DIFF
--- a/README.md~
+++ b/README.md~
@@ -1,3 +1,0 @@
-CARDIAC (CARDboard Illustrative Aid to Computation) Emulator
-============================================================
-This is an emulator, assembler, disassembler and memory visualizer that works exactly like the CARDIAC "Computor".

--- a/emulator/cpu-assembly.rkt
+++ b/emulator/cpu-assembly.rkt
@@ -12,8 +12,12 @@
 
 
 (define example-code (string-join '(
-				    "lit"
-				    "cla 8"
+				    "inp 7"
+				    "inp 8"
+				    "inp 10"
+				    "inp 97"
+				    "add 97"
+				    "sto 96"
 				    "nom"
 				    ) "\n"))
 
@@ -24,7 +28,6 @@
 								  `(,e ,(+ start-mem i)))
 								(cpu-encode code)
 								(build-list (length (cpu-encode code)) values)) #t))
-  (mem-change-callback memory-map)
   (cpu-execute (length (cpu-encode code)) memory-map input output acc mem-change-callback))
 
 (define decode-single-inst (lambda (instr)
@@ -81,12 +84,9 @@
   (define begin-pc (memory-access memory-map-start 0))
   (define memory-map-code-split (map (lambda (el)
 				       (define e (data-data el))
+				       (displayln el)
 				       (if (not (equal? e -1))
-					   (cond
-					    [(equal? (length (get-digits e)) 3)
-					     (list (first (get-digits e)) (concat-digits (rest (get-digits e))))]
-					    [(equal? (length (get-digits e)) 2)
-					     (list e)])
+					   (list (first (get-digits e)) (concat-digits (rest (get-digits e))))
 					   '(-1 -1))) (take (drop memory-map-start 1) 98)))
   
   (define code (filter exactly (map (lambda (e i)
@@ -101,7 +101,7 @@
 	   (define acc (or (second prev-state) acc-start))
 	   (define output-slot (or (third prev-state) output-slot-start))
 	   (define mode (fourth prev-state))
-	   (displayln mode)
+	   (displayln instruction)
 	   
 	   (match (if (not (equal? (first instruction) 0))
 		      (list (first (get-digits (first instruction))) (concat-digits (rest (get-digits (first instruction)))))

--- a/emulator/cpu-assembly.rkt
+++ b/emulator/cpu-assembly.rkt
@@ -101,11 +101,8 @@
 	   (define acc (or (second prev-state) acc-start))
 	   (define output-slot (or (third prev-state) output-slot-start))
 	   (define mode (fourth prev-state))
-	   (displayln instruction)
 	   
-	   (match (if (not (equal? (first instruction) 0))
-		      (list (first (get-digits (first instruction))) (concat-digits (rest (get-digits (first instruction)))))
-		      instruction)
+	   (match instruction
 	     [`(1 ,mloc)
 	      (cond
 	       [(equal? mode 'normal)

--- a/emulator/cpu-assembly.rkt
+++ b/emulator/cpu-assembly.rkt
@@ -12,12 +12,8 @@
 
 
 (define example-code (string-join '(
-				    "inp 7"
-				    "inp 8"
-				    "inp 10"
-				    "inp 97"
-				    "add 97"
-				    "sto 96"
+				    "lit"
+				    "cla 10"
 				    "nom"
 				    ) "\n"))
 
@@ -28,6 +24,7 @@
 								  `(,e ,(+ start-mem i)))
 								(cpu-encode code)
 								(build-list (length (cpu-encode code)) values)) #t))
+  (mem-change-callback memory-map)
   (cpu-execute (length (cpu-encode code)) memory-map input output acc mem-change-callback))
 
 (define decode-single-inst (lambda (instr)
@@ -84,7 +81,6 @@
   (define begin-pc (memory-access memory-map-start 0))
   (define memory-map-code-split (map (lambda (el)
 				       (define e (data-data el))
-				       (displayln el)
 				       (if (not (equal? e -1))
 					   (list (first (get-digits e)) (concat-digits (rest (get-digits e))))
 					   '(-1 -1))) (take (drop memory-map-start 1) 98)))

--- a/gui.rkt
+++ b/gui.rkt
@@ -22,6 +22,7 @@
 	       acc
 	       #:listener ; ->
 	       (lambda (mem)
+		 (sleep/yield 0.3)
 		 (for-each (lambda (e i)
 			     (define colors (map (lambda (e)
 						   (* (or e 0) 10))

--- a/gui.rkt
+++ b/gui.rkt
@@ -22,7 +22,7 @@
 	       acc
 	       #:listener ; ->
 	       (lambda (mem)
-		 (sleep/yield 0.3)
+		 (sleep/yield 0.2)
 		 (for-each (lambda (e i)
 			     (define colors (map (lambda (e)
 						   (* (or e 0) 10))


### PR DESCRIPTION
When the visualizer launches, and you make no modifications to memory, the callback is never called, so the memory map is never displayed. This is not very nice.
